### PR TITLE
 Eliminate compiler warning and runtime crash in threadstest

### DIFF
--- a/test/threadstest.h
+++ b/test/threadstest.h
@@ -62,15 +62,15 @@ static void *thread_run(void *arg)
 {
     void (*f)(void);
 
-    *(void **) (&f) = arg;
+    f = (void (*)()) arg;
 
-    f();
+    (*f)();
     return NULL;
 }
 
 static int run_thread(thread_t *t, void (*f)(void))
 {
-    return pthread_create(t, NULL, thread_run, *(void **) &f) == 0;
+    return pthread_create(t, NULL, thread_run, (void *)f) == 0;
 }
 
 static int wait_for_thread(thread_t thread)


### PR DESCRIPTION
With GCC 4.1.0 building for Linux ppc (32-bit big-endian) or linux 390 (31-bit), threadstest.h causes this warning at build time:

```
gcc  -Iinclude -Iapps/include  -pthread -m31 -Wa,-mzarch -DTERMIO -O3 -Wall -Wall -O3 -DOPENSSL_BUILDING_OPENSSL -DNDEBUG  -MMD -MF test/threadstest-bin-threadstest.d.tmp -MT test/threadstest-bin-threadstest.o -c -o test/threadstest-bin-threadstest.o test/threadstest.c
In file included from test/threadstest.c:23:
test/threadstest.h: In function 'thread_run':
test/threadstest.h:65: warning: dereferencing type-punned pointer will break strict-aliasing rules
test/threadstest.h: In function 'run_thread':
test/threadstest.h:73: warning: dereferencing type-punned pointer will break strict-aliasing rules
```

At run-time, the threadstest program core dumps with a stack trace going through a null instruction pointer when the thread attempts to call through thread_run.

The type conversion casts through `&f` can be replaced by a simple cast, which eliminates the warning and fixes the core dump in the test program.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
- [x] tests are added or updated
